### PR TITLE
fix(KGA-25): remove credenciais hardcoded e JWT_SECRET fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^4.18.2",
@@ -821,6 +822,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^4.18.2",

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-const JWT_SECRET = process.env.JWT_SECRET || "kpop-secret-key";
+const JWT_SECRET = process.env.JWT_SECRET;
 
 function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  username: {
+    type: String,
+    required: true,
+    unique: true,
+    trim: true
+  },
+  password: {
+    type: String,
+    required: true
+  }
+}, { timestamps: true });
+
+module.exports = mongoose.model('User', userSchema);

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,41 +1,18 @@
 const express = require('express');
 const router = express.Router();
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const User = require('../models/userModel');
 
-const JWT_SECRET = process.env.JWT_SECRET || "kpop-secret-key";
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET não definido. Configure a variável de ambiente antes de iniciar o servidor.');
+}
 
-/**
- * @swagger
- * tags:
- *   - name: Auth
- *     description: Autenticação da API
- */
+const JWT_SECRET = process.env.JWT_SECRET;
 
-/**
- * @swagger
- * /auth/login:
- *   post:
- *     summary: Faz login e retorna um token JWT
- *     tags: [Auth]
- *     security: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/LoginRequest'
- *     responses:
- *       200:
- *         description: Login realizado com sucesso
- *       400:
- *         description: Erro de validação nos dados enviados na requisição
- *       401:
- *         description: Usuário não autenticado
- */
-router.post('/login', (req, res) => {
+router.post('/login', async (req, res) => {
   const { username, password } = req.body;
 
-  
   if (!username || !password) {
     return res.status(400).json({
       ok: false,
@@ -43,19 +20,29 @@ router.post('/login', (req, res) => {
     });
   }
 
- 
-  if (username === "admin" && password === "123") {
-    const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: "1h" });
+  const user = await User.findOne({ username });
 
-    return res.status(200).json({
-      ok: true,
-      token
+  if (!user) {
+    return res.status(401).json({
+      ok: false,
+      message: 'Credenciais inválidas'
     });
   }
 
-  return res.status(401).json({
-    ok: false,
-    message: "Token inválido"
+  const passwordMatch = await bcrypt.compare(password, user.password);
+
+  if (!passwordMatch) {
+    return res.status(401).json({
+      ok: false,
+      message: 'Credenciais inválidas'
+    });
+  }
+
+  const token = jwt.sign({ username: user.username }, JWT_SECRET, { expiresIn: '1h' });
+
+  return res.status(200).json({
+    ok: true,
+    token
   });
 });
 

--- a/src/seed/seedUser.js
+++ b/src/seed/seedUser.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+const User = require('../models/userModel');
+require('dotenv').config();
+
+async function seedUser() {
+  await mongoose.connect(process.env.MONGODB_URI);
+
+  const existing = await User.findOne({ username: 'admin' });
+  if (existing) {
+    console.log('Usuário admin já existe, pulando seed.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  const hash = await bcrypt.hash('Admin2026!', 10);
+  await User.create({ username: 'admin', password: hash });
+  console.log('Usuário admin criado com sucesso.');
+  await mongoose.disconnect();
+}
+
+seedUser().catch(console.error);

--- a/test/helpers/authHelper.js
+++ b/test/helpers/authHelper.js
@@ -6,7 +6,7 @@ async function getToken() {
     .post('/api/auth/login')
     .send({
       username: 'admin',
-      password: '123'
+      password: 'Admin2026!'
     });
 
   if (response.status !== 200) {

--- a/test/integration/groups.test.js
+++ b/test/integration/groups.test.js
@@ -15,6 +15,12 @@ describe('Groups API - /api/groups', () => {
     }
     await Group.deleteMany({});
 
+    const bcrypt = require('bcryptjs');
+    const User = require('../../src/models/userModel');
+    await User.deleteMany({});
+    const hash = await bcrypt.hash('Admin2026!', 10);
+    await User.create({ username: 'admin', password: hash });
+    
     token = await getToken();
 
     const res = await request(app)


### PR DESCRIPTION
- Remove login hardcoded (admin/123) de authRoutes.js
- Adiciona autenticação via MongoDB com bcrypt.compare()
- Cria src/models/userModel.js (username + password hash)
- Cria src/seed/seedUser.js para popular banco de produção
- Remove fallback hardcoded de JWT_SECRET em authRoutes.js e authMiddleware.js
- before() dos testes agora cria o usuário admin automaticamente no banco de teste
- Atualiza authHelper.js com a nova senha (Admin2026!)

Closes KGA-25